### PR TITLE
Allow the canvas to not fill the whole window

### DIFF
--- a/site/gearsketch_main.js
+++ b/site/gearsketch_main.js
@@ -84,6 +84,8 @@
       this.loadDemoPointer();
       this.loadBoard();
       this.canvas = document.getElementById("gearsketch_canvas");
+      this.canvasOffsetX = this.canvas.getBoundingClientRect().left;
+      this.canvasOffsetY = this.canvas.getBoundingClientRect().top;
       this.isDemoPlaying = false;
       this.updateCanvasSize();
       this.addCanvasListeners();
@@ -187,18 +189,24 @@
     };
 
     GearSketch.prototype.forwardPenDownEvent = function(event) {
+      var x, y;
       event.gesture.preventDefault();
       if (this.isDemoPlaying) {
         return this.stopDemo();
       } else {
-        return this.handlePenDown(event.gesture.center.pageX, event.gesture.center.pageY);
+        x = event.gesture.center.pageX - this.canvasOffsetX;
+        y = event.gesture.center.pageY - this.canvasOffsetY;
+        return this.handlePenDown(x, y);
       }
     };
 
     GearSketch.prototype.forwardPenMoveEvent = function(event) {
+      var x, y;
       event.gesture.preventDefault();
       if (!this.isDemoPlaying) {
-        return this.handlePenMove(event.gesture.center.pageX, event.gesture.center.pageY);
+        x = event.gesture.center.pageX - this.canvasOffsetX;
+        y = event.gesture.center.pageY - this.canvasOffsetY;
+        return this.handlePenMove(x, y);
       }
     };
 
@@ -731,8 +739,8 @@
     };
 
     GearSketch.prototype.updateCanvasSize = function() {
-      this.canvas.width = window.innerWidth;
-      this.canvas.height = window.innerHeight;
+      this.canvas.width = this.canvas.parentElement.getBoundingClientRect().width;
+      this.canvas.height = this.canvas.parentElement.getBoundingClientRect().height;
       this.buttons["clearButton"].location.x = Math.max(this.canvas.width - 260, this.buttons["playButton"].location.x + 80);
       this.buttons["cloudButton"].location.x = this.buttons["clearButton"].location.x + 80;
       return this.buttons["helpButton"].location.x = this.buttons["cloudButton"].location.x + 80;

--- a/src/gearsketch_main.coffee
+++ b/src/gearsketch_main.coffee
@@ -79,6 +79,8 @@ class GearSketch
     @loadDemoPointer()
     @loadBoard()
     @canvas = document.getElementById("gearsketch_canvas")
+    @canvasOffsetX = @canvas.getBoundingClientRect().left
+    @canvasOffsetY = @canvas.getBoundingClientRect().top
     @isDemoPlaying = false
     @updateCanvasSize()
     @addCanvasListeners()
@@ -142,12 +144,16 @@ class GearSketch
     if @isDemoPlaying
       @stopDemo()
     else
-      @handlePenDown(event.gesture.center.pageX, event.gesture.center.pageY)
+      x = event.gesture.center.pageX - @canvasOffsetX
+      y = event.gesture.center.pageY - @canvasOffsetY
+      @handlePenDown(x, y)
 
   forwardPenMoveEvent: (event) ->
     event.gesture.preventDefault()
     unless @isDemoPlaying
-      @handlePenMove(event.gesture.center.pageX, event.gesture.center.pageY)
+      x = event.gesture.center.pageX - @canvasOffsetX
+      y = event.gesture.center.pageY - @canvasOffsetY
+      @handlePenMove(x, y)
 
   forwardPenUpEvent: (event) ->
     unless @isDemoPlaying
@@ -581,8 +587,8 @@ class GearSketch
         @drawDemoPointer(ctx, @pointerLocation)
 
   updateCanvasSize: () ->
-    @canvas.width = window.innerWidth
-    @canvas.height = window.innerHeight
+    @canvas.width = @canvas.parentElement.getBoundingClientRect().width
+    @canvas.height = @canvas.parentElement.getBoundingClientRect().height
     @buttons["clearButton"].location.x = Math.max(@canvas.width - 260, @buttons["playButton"].location.x + 80)
     @buttons["cloudButton"].location.x = @buttons["clearButton"].location.x + 80
     @buttons["helpButton"].location.x = @buttons["cloudButton"].location.x + 80


### PR DESCRIPTION
- Consider the offset that can be between the canvas and the window.
  The previous code matched the entire window.  But it was behaving
  bad if a toolbar or a header was added above the canvas.
- Make the canvas fill its parent element, not the entire window.
